### PR TITLE
Enhancement: Add interface and finder

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -13,7 +13,9 @@ EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php56($header));
 
-$config->getFinder()->in(__DIR__);
+$config->getFinder()
+    ->in(__DIR__)
+    ->exclude('test/Unit/Asset/Definition/CanNotBeAutoloaded');
 
 $cacheDir = \getenv('TRAVIS') ? \getenv('HOME') . '/.php-cs-fixer' : __DIR__;
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 [![Latest Stable Version](https://poser.pugx.org/localheinz/factory-girl-definition/v/stable)](https://packagist.org/packages/localheinz/factory-girl-definition)
 [![Total Downloads](https://poser.pugx.org/localheinz/factory-girl-definition/downloads)](https://packagist.org/packages/localheinz/factory-girl-definition)
 
+Provides an interface for, and an easy way to find and register entity definitions for [`breerly/factory-girl-php`](https://github.com/breerly/factory-girl-php).
+
 ## Installation
 
 Run
@@ -17,7 +19,77 @@ $ composer require localheinz/factory-girl-definition
 
 ## Usage
 
-:bulb: This is a great place for showing a few usage examples!
+### Create Definitions
+
+Implement the `Definition` interface and use the instance of `FactoryGirl\Provider\Doctrine\FixtureFactory` 
+that is passed in into `accept()` to define entities:
+
+```php
+<?php
+
+namespace Foo\Bar\Test\Fixture\Entity;
+
+use FactoryGirl\Provider\Doctrine\FixtureFactory;
+use Foo\Bar\Entity;
+use Localheinz\FactoryGirl\Definition\Definition;
+
+final class UserProvider implements Definition
+{
+    public function accept(FixtureFactory $fixtureFactory)
+    {
+        $fixtureFactory->defineEntity(Entity\User::class, [
+            // ...
+        ]);
+    }
+}
+```
+
+:bulb: Any number of entities can be defined within a definition.
+However, it's probably a good idea to create a definition for each entity. 
+ 
+### Register Definitions
+
+Lazily instantiate an instance of `FactoryGirl\Provider\Doctrine\FixtureFactory` 
+and use `Definitions` to find definitions and register them with the factory:
+ 
+```php
+<?php
+
+namespace Foo\Bar\Test\Integration;
+
+use Doctrine\ORM;
+use FactoryGirl\Provider\Doctrine\FixtureFactory;
+use Localheinz\FactoryGirl\Definition\Definitions;
+use PHPUnit\Framework;
+
+abstract class AbstractIntegrationTestCase extends Framework\TestCase
+{
+    /**
+     * @return ORM\EntityManager
+     */
+    final protected function entityManager()
+    {
+        // ...
+    }
+    
+    /**
+     * @return FixtureFactory
+     */
+    final protected function fixtureFactory()
+    {
+        static $fixtureFactory = null;
+        
+        if (null === $fixtureFactory) {
+            $fixtureFactory = new Doctrine\FixtureFactory($entityManager);
+            $fixtureFactory->persistOnGet(true);
+            
+            Definitions::in(__DIR__ . '/../Fixture')->registerWith($fixtureFactory);
+        }
+        
+        return $fixtureFactory;
+    }
+}
+```
 
 ## Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "localheinz/factory-girl-definition",
-  "description": "Provides an interface and a finder for definitions with breerly/factory-girl-php.",
+  "description": "Provides an interface for, and an easy way to find and register entity definitions for breerly/factory-girl-php.",
   "type": "library",
   "license": "MIT",
   "authors": [
@@ -13,13 +13,21 @@
     "preferred-install": "dist",
     "sort-packages": true
   },
+  "minimum-stability": "beta",
+  "prefer-stable": true,
   "require": {
-    "php": "^5.6 || ^7.0"
+    "php": "^5.6 || ^7.0",
+    "zendframework/zend-file": "^2.7.1"
   },
   "require-dev": {
+    "breerly/factory-girl-php": "^1.0.0",
     "codeclimate/php-test-reporter": "0.4.4",
     "localheinz/php-cs-fixer-config": "1.2.1",
-    "phpunit/phpunit": "^5.7.20"
+    "phpunit/phpunit": "^5.7.20",
+    "refinery29/test-util": "^0.11.3"
+  },
+  "suggest": {
+    "breerly/factory-girl-php": "For creating a fixture factory the definitions can be used with."
   },
   "autoload": {
     "psr-4": {

--- a/src/Definition.php
+++ b/src/Definition.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Copyright (c) 2017 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition;
+
+use FactoryGirl\Provider\Doctrine\FixtureFactory;
+
+interface Definition
+{
+    public function accept(FixtureFactory $fixtureFactory);
+}

--- a/src/Definitions.php
+++ b/src/Definitions.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Copyright (c) 2017 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition;
+
+use FactoryGirl\Provider\Doctrine\FixtureFactory;
+use Zend\File;
+
+final class Definitions
+{
+    /**
+     * @var Definition[]
+     */
+    private $definitions = [];
+
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param string $directory
+     *
+     * @throws Exception\InvalidDirectory
+     * @throws Exception\InvalidDefinition
+     *
+     * @return self
+     */
+    public static function in($directory)
+    {
+        if (!\is_string($directory)) {
+            throw Exception\InvalidDirectory::notString($directory);
+        }
+
+        if (!\is_dir($directory)) {
+            throw Exception\InvalidDirectory::notDirectory($directory);
+        }
+
+        $locator = new File\ClassFileLocator($directory);
+
+        /** @var File\PhpClassFile[] $files */
+        $files = \iterator_to_array($locator);
+
+        $instance = new self();
+
+        foreach ($files as $file) {
+            foreach ($file->getClasses() as $className) {
+                try {
+                    $reflection = new \ReflectionClass($className);
+                } catch (\ReflectionException $exception) {
+                    continue;
+                }
+
+                if (!$reflection->isSubclassOf(Definition::class) || $reflection->isAbstract()) {
+                    continue;
+                }
+
+                try {
+                    $definition = $reflection->newInstance();
+                } catch (\Exception $exception) {
+                    throw Exception\InvalidDefinition::fromClassNameAndException(
+                        $className,
+                        $exception
+                    );
+                }
+
+                $instance->definitions[] = $definition;
+            }
+        }
+
+        return $instance;
+    }
+
+    public function registerWith(FixtureFactory $fixtureFactory)
+    {
+        foreach ($this->definitions as $definition) {
+            $definition->accept($fixtureFactory);
+        }
+    }
+}

--- a/src/Exception/InvalidDefinition.php
+++ b/src/Exception/InvalidDefinition.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Copyright (c) 2017 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Exception;
+
+final class InvalidDefinition extends \RuntimeException
+{
+    /**
+     * @param string     $className
+     * @param \Exception $exception
+     *
+     * @return self
+     */
+    public static function fromClassNameAndException($className, \Exception $exception)
+    {
+        return new self(
+            \sprintf(
+                'An exception was thrown while trying to instantiate definition "%s".',
+                $className
+            ),
+            null,
+            $exception
+        );
+    }
+}

--- a/src/Exception/InvalidDirectory.php
+++ b/src/Exception/InvalidDirectory.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Copyright (c) 2017 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Exception;
+
+final class InvalidDirectory extends \InvalidArgumentException
+{
+    /**
+     * @param mixed $directory
+     *
+     * @return self
+     */
+    public static function notString($directory)
+    {
+        return new self(\sprintf(
+            'Directory should be a string, got %s instead.',
+            \is_object($directory) ? \get_class($directory) : \gettype($directory)
+        ));
+    }
+
+    /**
+     * @param string $directory
+     *
+     * @return self
+     */
+    public static function notDirectory($directory)
+    {
+        return new self(\sprintf(
+            'Directory should be a directory, but "%s" is not.',
+            $directory
+        ));
+    }
+}

--- a/test/Unit/Asset/Definition/Acceptable/UserDefinition.php
+++ b/test/Unit/Asset/Definition/Acceptable/UserDefinition.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Copyright (c) 2017 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Definition\Acceptable;
+
+use FactoryGirl\Provider\Doctrine\FixtureFactory;
+use Localheinz\FactoryGirl\Definition\Definition;
+
+/**
+ * Is acceptable as it implements the ProviderInterface.
+ */
+final class UserDefinition implements Definition
+{
+    public function accept(FixtureFactory $factory)
+    {
+        $factory->defineEntity('Foo');
+    }
+}

--- a/test/Unit/Asset/Definition/CanNotBeAutoloaded/UserDefinition.php
+++ b/test/Unit/Asset/Definition/CanNotBeAutoloaded/UserDefinition.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Copyright (c) 2017 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Definition\CanNotBeAutoloaded;
+
+use FactoryGirl\Provider\Doctrine\FixtureFactory;
+use Localheinz\FactoryGirl\Definition\Definition;
+
+/**
+ * Is not acceptable as it can not be autoloaded (class name does not match file name).
+ */
+final class MaybeUserDefinition implements Definition
+{
+    public function accept(FixtureFactory $factory)
+    {
+        $factory->defineEntity('Foo');
+    }
+}

--- a/test/Unit/Asset/Definition/DoesNotImplementInterface/UserDefinition.php
+++ b/test/Unit/Asset/Definition/DoesNotImplementInterface/UserDefinition.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Copyright (c) 2017 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Definition\DoesNotImplementInterface;
+
+use FactoryGirl\Provider\Doctrine\FixtureFactory;
+
+/**
+ * Is not acceptable as it does not implement the DefinitionInterface.
+ */
+final class UserDefinition
+{
+    public function accept(FixtureFactory $factory)
+    {
+        $factory->defineEntity('Foo');
+    }
+}

--- a/test/Unit/Asset/Definition/IsAbstract/UserDefinition.php
+++ b/test/Unit/Asset/Definition/IsAbstract/UserDefinition.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Copyright (c) 2017 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Definition\IsAbstract;
+
+use FactoryGirl\Provider\Doctrine\FixtureFactory;
+use Localheinz\FactoryGirl\Definition\Definition;
+use Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Entity;
+
+/**
+ * Is not acceptable as it is abstract.
+ */
+abstract class UserDefinition implements Definition
+{
+    public function accept(FixtureFactory $factory)
+    {
+        $factory->defineEntity(Entity\User::class);
+    }
+}

--- a/test/Unit/Asset/Definition/ThrowsExceptionDuringConstruction/UserDefinition.php
+++ b/test/Unit/Asset/Definition/ThrowsExceptionDuringConstruction/UserDefinition.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Copyright (c) 2017 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Definition\ThrowsExceptionDuringConstruction;
+
+use FactoryGirl\Provider\Doctrine\FixtureFactory;
+use Localheinz\FactoryGirl\Definition\Definition;
+use Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Entity;
+
+/**
+ * Is not acceptable as it throws an exception during construction.
+ */
+final class UserDefinition implements Definition
+{
+    public function __construct()
+    {
+        throw new \RuntimeException();
+    }
+
+    public function accept(FixtureFactory $factory)
+    {
+        $factory->defineEntity(Entity\User::class);
+    }
+}

--- a/test/Unit/Asset/Entity/User.php
+++ b/test/Unit/Asset/Entity/User.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Copyright (c) 2017 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Entity;
+
+final class User
+{
+}

--- a/test/Unit/DefinitionsTest.php
+++ b/test/Unit/DefinitionsTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Copyright (c) 2017 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Test\Unit;
+
+use FactoryGirl\Provider\Doctrine\FixtureFactory;
+use Localheinz\FactoryGirl\Definition\Definitions;
+use Localheinz\FactoryGirl\Definition\Exception;
+use PHPUnit\Framework;
+use Refinery29\Test\Util;
+
+final class DefinitionsTest extends Framework\TestCase
+{
+    use Util\TestHelper;
+
+    /**
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $directory
+     */
+    public function testInRejectsInvalidString($directory)
+    {
+        $this->expectException(Exception\InvalidDirectory::class);
+
+        Definitions::in($directory);
+    }
+
+    public function testInRejectsNonExistentDirectory()
+    {
+        $this->expectException(Exception\InvalidDirectory::class);
+
+        Definitions::in(__DIR__ . '/Asset/Definition/NonExistentDirectory');
+    }
+
+    public function testInIgnoresClassesWhichCanNotBeAutoloaded()
+    {
+        $fixtureFactory = $this->createFixtureFactoryMock();
+
+        $fixtureFactory
+            ->expects($this->never())
+            ->method($this->anything());
+
+        Definitions::in(__DIR__ . '/Asset/Definition/CanNotBeAutoloaded')->registerWith($fixtureFactory);
+    }
+
+    public function testInIgnoresClassesWhichDoNotImplementProviderInterface()
+    {
+        $fixtureFactory = $this->createFixtureFactoryMock();
+
+        $fixtureFactory
+            ->expects($this->never())
+            ->method($this->anything());
+
+        Definitions::in(__DIR__ . '/Asset/Definition/DoesNotImplementInterface')->registerWith($fixtureFactory);
+    }
+
+    public function testInIgnoresClassesWhichAreAbstract()
+    {
+        $fixtureFactory = $this->createFixtureFactoryMock();
+
+        $fixtureFactory
+            ->expects($this->never())
+            ->method($this->anything());
+
+        Definitions::in(__DIR__ . '/Asset/Definition/IsAbstract')->registerWith($fixtureFactory);
+    }
+
+    public function testInAcceptsClassesWhichAreAcceptable()
+    {
+        $fixtureFactory = $this->createFixtureFactoryMock();
+
+        $fixtureFactory
+            ->expects($this->once())
+            ->method('defineEntity');
+
+        Definitions::in(__DIR__ . '/Asset/Definition/Acceptable')->registerWith($fixtureFactory);
+    }
+
+    public function testThrowsInvalidDefinitionExceptionIfInstantiatingDefinitionsThrowsException()
+    {
+        $fixtureFactory = $this->createFixtureFactoryMock();
+
+        $fixtureFactory
+            ->expects($this->never())
+            ->method($this->anything());
+
+        $this->expectException(Exception\InvalidDefinition::class);
+
+        Definitions::in(__DIR__ . '/Asset/Definition/ThrowsExceptionDuringConstruction');
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|FixtureFactory
+     */
+    private function createFixtureFactoryMock()
+    {
+        return $this->createMock(FixtureFactory::class);
+    }
+}

--- a/test/Unit/Exception/InvalidDefinitionTest.php
+++ b/test/Unit/Exception/InvalidDefinitionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * Copyright (c) 2017 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Test\Unit\Exception;
+
+use Localheinz\FactoryGirl\Definition\Exception;
+use PHPUnit\Framework;
+use Refinery29\Test\Util;
+
+final class InvalidDefinitionTest extends Framework\TestCase
+{
+    use Util\TestHelper;
+
+    public function testExtendsRuntimeException()
+    {
+        $this->assertExtends(\RuntimeException::class, Exception\InvalidDefinition::class);
+    }
+
+    public function testFromClassNameCreatesException()
+    {
+        $className = $this->getFaker()->word;
+        $previousException = new \Exception();
+
+        $exception = Exception\InvalidDefinition::fromClassNameAndException(
+            $className,
+            $previousException
+        );
+
+        $this->assertInstanceOf(Exception\InvalidDefinition::class, $exception);
+
+        $message = \sprintf(
+            'An exception was thrown while trying to instantiate definition "%s".',
+            $className
+        );
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame($previousException, $exception->getPrevious());
+    }
+}

--- a/test/Unit/Exception/InvalidDirectoryTest.php
+++ b/test/Unit/Exception/InvalidDirectoryTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * Copyright (c) 2017 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Test\Unit\Exception;
+
+use Localheinz\FactoryGirl\Definition\Exception;
+use PHPUnit\Framework;
+use Refinery29\Test\Util;
+
+final class InvalidDirectoryTest extends Framework\TestCase
+{
+    use Util\TestHelper;
+
+    public function testExtendsInvalidArgumentException()
+    {
+        $this->assertExtends(\InvalidArgumentException::class, Exception\InvalidDirectory::class);
+    }
+
+    /**
+     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidString::data()
+     *
+     * @param mixed $directory
+     */
+    public function testNotStringCreatesException($directory)
+    {
+        $exception = Exception\InvalidDirectory::notString($directory);
+
+        $this->assertInstanceOf(Exception\InvalidDirectory::class, $exception);
+
+        $message = \sprintf(
+            'Directory should be a string, got %s instead.',
+            \is_object($directory) ? \get_class($directory) : \gettype($directory)
+        );
+
+        $this->assertSame($message, $exception->getMessage());
+    }
+
+    public function testNotDirectoryCreatesException()
+    {
+        $directory = $this->getFaker()->word;
+
+        $exception = Exception\InvalidDirectory::notDirectory($directory);
+
+        $this->assertInstanceOf(Exception\InvalidDirectory::class, $exception);
+
+        $message = \sprintf(
+            'Directory should be a directory, but "%s" is not.',
+            $directory
+        );
+
+        $this->assertSame($message, $exception->getMessage());
+    }
+}

--- a/test/Unit/ProjectCodeTest.php
+++ b/test/Unit/ProjectCodeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Copyright (c) 2017 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Test\Unit;
+
+use Refinery29\Test\Util;
+
+final class ProjectCodeTest extends \PHPUnit_Framework_TestCase
+{
+    use Util\TestHelper;
+
+    public function testProductionCodeIsAbstractOrFinal()
+    {
+        $this->assertClassesAreAbstractOrFinal(__DIR__ . '/../../src');
+    }
+
+    public function testTestCodeIsAbstractOrFinal()
+    {
+        $this->assertClassesAreAbstractOrFinal(__DIR__ . '/..', [
+            'Unit/Asset/Definition/CanNotBeAutoloaded',
+        ]);
+    }
+}


### PR DESCRIPTION
This PR

* [x] adds a `Definition` interface and `Definitions`, which can be used to find implementations of the `Definition` interface and register them with a `FactoryGirl\Provider\Doctrine\FixtureFactory`