### PR TITLE
Fix: Use Definition instead of Provider in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ use FactoryGirl\Provider\Doctrine\FixtureFactory;
 use Foo\Bar\Entity;
 use Localheinz\FactoryGirl\Definition\Definition;
 
-final class UserProvider implements Definition
+final class UserDefinition implements Definition
 {
     public function accept(FixtureFactory $fixtureFactory)
     {


### PR DESCRIPTION
This PR

* [x] uses `Definition` instead of `Provider` as class suffix in an example in `README.md` 

Follows #1.