### PR TITLE
Fix: Ignore definitions with private constructors

### DIFF
--- a/src/Definitions.php
+++ b/src/Definitions.php
@@ -58,7 +58,7 @@ final class Definitions
                     continue;
                 }
 
-                if (!$reflection->isSubclassOf(Definition::class) || $reflection->isAbstract()) {
+                if (!$reflection->isSubclassOf(Definition::class) || !$reflection->isInstantiable()) {
                     continue;
                 }
 

--- a/test/Unit/Asset/Definition/PrivateConstructor/UserDefinition.php
+++ b/test/Unit/Asset/Definition/PrivateConstructor/UserDefinition.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * Copyright (c) 2017 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Definition\PrivateConstructor;
+
+use FactoryGirl\Provider\Doctrine\FixtureFactory;
+use Localheinz\FactoryGirl\Definition\Definition;
+
+/**
+ * Is not acceptable as it has a private constructor.
+ */
+final class UserDefinition implements Definition
+{
+    private function __construct()
+    {
+    }
+
+    public function accept(FixtureFactory $factory)
+    {
+        $factory->defineEntity('Foo');
+    }
+}

--- a/test/Unit/DefinitionsTest.php
+++ b/test/Unit/DefinitionsTest.php
@@ -73,6 +73,17 @@ final class DefinitionsTest extends Framework\TestCase
         Definitions::in(__DIR__ . '/Asset/Definition/IsAbstract')->registerWith($fixtureFactory);
     }
 
+    public function testInIgnoresClassesWhichHavePrivateConstructors()
+    {
+        $fixtureFactory = $this->createFixtureFactoryMock();
+
+        $fixtureFactory
+            ->expects($this->never())
+            ->method($this->anything());
+
+        Definitions::in(__DIR__ . '/Asset/Definition/PrivateConstructor')->registerWith($fixtureFactory);
+    }
+
     public function testInAcceptsClassesWhichAreAcceptable()
     {
         $fixtureFactory = $this->createFixtureFactoryMock();


### PR DESCRIPTION
This PR

* [x] asserts that definitions with `private` constructors are ignored
* [x] ignores definitions with `private` constructors