### PR TITLE
Fix: Raise minimum stability to default levels

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,6 @@
     "preferred-install": "dist",
     "sort-packages": true
   },
-  "minimum-stability": "beta",
-  "prefer-stable": true,
   "require": {
     "php": "^5.6 || ^7.0",
     "zendframework/zend-file": "^2.7.1"


### PR DESCRIPTION
This PR

* [x] raises the minimum stability level to default levels

Follows https://github.com/breerly/factory-girl-php/releases/tag/1.0.0.