### PR TITLE
Fix: Drop support for PHP 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,6 @@ env:
 
 matrix:
   include:
-    - php: 5.6
-      env: WITH_LOWEST=true
-    - php: 5.6
-      env: WITH_LOCKED=true WITH_CS=true
-    - php: 5.6
-      env: WITH_HIGHEST=true
     - php: 7.0
       env: WITH_LOWEST=true
     - php: 7.0

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "sort-packages": true
   },
   "require": {
-    "php": "^5.6 || ^7.0",
+    "php": "^7.0",
     "zendframework/zend-file": "^2.7.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4baa8d4c963eb3486915a83780f777b2",
+    "content-hash": "d6bdcf7690309b396e8505a2d4191da5",
     "packages": [
         {
             "name": "zendframework/zend-file",
@@ -3504,7 +3504,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.6 || ^7.0"
+        "php": "^7.0"
     },
     "platform-dev": []
 }

--- a/src/Definitions.php
+++ b/src/Definitions.php
@@ -33,12 +33,8 @@ final class Definitions
      *
      * @return self
      */
-    public static function in($directory)
+    public static function in(string $directory)
     {
-        if (!\is_string($directory)) {
-            throw Exception\InvalidDirectory::notString($directory);
-        }
-
         if (!\is_dir($directory)) {
             throw Exception\InvalidDirectory::notDirectory($directory);
         }

--- a/src/Exception/InvalidDefinition.php
+++ b/src/Exception/InvalidDefinition.php
@@ -13,13 +13,7 @@ namespace Localheinz\FactoryGirl\Definition\Exception;
 
 final class InvalidDefinition extends \RuntimeException
 {
-    /**
-     * @param string     $className
-     * @param \Exception $exception
-     *
-     * @return self
-     */
-    public static function fromClassNameAndException($className, \Exception $exception)
+    public static function fromClassNameAndException(string $className, \Exception $exception): self
     {
         return new self(
             \sprintf(

--- a/src/Exception/InvalidDirectory.php
+++ b/src/Exception/InvalidDirectory.php
@@ -13,25 +13,7 @@ namespace Localheinz\FactoryGirl\Definition\Exception;
 
 final class InvalidDirectory extends \InvalidArgumentException
 {
-    /**
-     * @param mixed $directory
-     *
-     * @return self
-     */
-    public static function notString($directory)
-    {
-        return new self(\sprintf(
-            'Directory should be a string, got %s instead.',
-            \is_object($directory) ? \get_class($directory) : \gettype($directory)
-        ));
-    }
-
-    /**
-     * @param string $directory
-     *
-     * @return self
-     */
-    public static function notDirectory($directory)
+    public static function notDirectory(string $directory): self
     {
         return new self(\sprintf(
             'Directory should be a directory, but "%s" is not.',

--- a/test/Unit/DefinitionsTest.php
+++ b/test/Unit/DefinitionsTest.php
@@ -21,18 +21,6 @@ final class DefinitionsTest extends Framework\TestCase
 {
     use Util\TestHelper;
 
-    /**
-     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidString::data()
-     *
-     * @param mixed $directory
-     */
-    public function testInRejectsInvalidString($directory)
-    {
-        $this->expectException(Exception\InvalidDirectory::class);
-
-        Definitions::in($directory);
-    }
-
     public function testInRejectsNonExistentDirectory()
     {
         $this->expectException(Exception\InvalidDirectory::class);

--- a/test/Unit/Exception/InvalidDirectoryTest.php
+++ b/test/Unit/Exception/InvalidDirectoryTest.php
@@ -24,25 +24,6 @@ final class InvalidDirectoryTest extends Framework\TestCase
         $this->assertExtends(\InvalidArgumentException::class, Exception\InvalidDirectory::class);
     }
 
-    /**
-     * @dataProvider \Refinery29\Test\Util\DataProvider\InvalidString::data()
-     *
-     * @param mixed $directory
-     */
-    public function testNotStringCreatesException($directory)
-    {
-        $exception = Exception\InvalidDirectory::notString($directory);
-
-        $this->assertInstanceOf(Exception\InvalidDirectory::class, $exception);
-
-        $message = \sprintf(
-            'Directory should be a string, got %s instead.',
-            \is_object($directory) ? \get_class($directory) : \gettype($directory)
-        );
-
-        $this->assertSame($message, $exception->getMessage());
-    }
-
     public function testNotDirectoryCreatesException()
     {
         $directory = $this->getFaker()->word;


### PR DESCRIPTION
This PR

* [x] drops support for PHP 5.6

💁‍♂️ It has security support until 2018-12-03, but I really don't want to support it anymore.

For reference, see http://php.net/supported-versions.php:

![screen shot 2017-09-19 at 07 31 37](https://user-images.githubusercontent.com/605483/30577147-9dd250b6-9d0c-11e7-8869-9d0e1fd461b3.png)
