### PR TITLE
Fix: Move fixtures into dedicated namespace

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -15,7 +15,7 @@ $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php56($header));
 
 $config->getFinder()
     ->in(__DIR__)
-    ->exclude('test/Unit/Asset/Definition/CanNotBeAutoloaded');
+    ->exclude('test/Fixture/Definition/CanNotBeAutoloaded');
 
 $cacheDir = \getenv('TRAVIS') ? \getenv('HOME') . '/.php-cs-fixer' : __DIR__;
 

--- a/test/Fixture/Definition/Acceptable/UserDefinition.php
+++ b/test/Fixture/Definition/Acceptable/UserDefinition.php
@@ -9,7 +9,7 @@
  * @link https://github.com/localheinz/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Definition\Acceptable;
+namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\Acceptable;
 
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
 use Localheinz\FactoryGirl\Definition\Definition;

--- a/test/Fixture/Definition/CanNotBeAutoloaded/UserDefinition.php
+++ b/test/Fixture/Definition/CanNotBeAutoloaded/UserDefinition.php
@@ -9,7 +9,7 @@
  * @link https://github.com/localheinz/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Definition\CanNotBeAutoloaded;
+namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\CanNotBeAutoloaded;
 
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
 use Localheinz\FactoryGirl\Definition\Definition;

--- a/test/Fixture/Definition/DoesNotImplementInterface/UserDefinition.php
+++ b/test/Fixture/Definition/DoesNotImplementInterface/UserDefinition.php
@@ -9,19 +9,17 @@
  * @link https://github.com/localheinz/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Definition\IsAbstract;
+namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\DoesNotImplementInterface;
 
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
-use Localheinz\FactoryGirl\Definition\Definition;
-use Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Entity;
 
 /**
- * Is not acceptable as it is abstract.
+ * Is not acceptable as it does not implement the DefinitionInterface.
  */
-abstract class UserDefinition implements Definition
+final class UserDefinition
 {
     public function accept(FixtureFactory $factory)
     {
-        $factory->defineEntity(Entity\User::class);
+        $factory->defineEntity('Foo');
     }
 }

--- a/test/Fixture/Definition/IsAbstract/UserDefinition.php
+++ b/test/Fixture/Definition/IsAbstract/UserDefinition.php
@@ -9,24 +9,18 @@
  * @link https://github.com/localheinz/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Definition\ThrowsExceptionDuringConstruction;
+namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\IsAbstract;
 
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
 use Localheinz\FactoryGirl\Definition\Definition;
-use Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Entity;
 
 /**
- * Is not acceptable as it throws an exception during construction.
+ * Is not acceptable as it is abstract.
  */
-final class UserDefinition implements Definition
+abstract class UserDefinition implements Definition
 {
-    public function __construct()
-    {
-        throw new \RuntimeException();
-    }
-
     public function accept(FixtureFactory $factory)
     {
-        $factory->defineEntity(Entity\User::class);
+        $factory->defineEntity(\Localheinz\FactoryGirl\Definition\Test\Fixture\Entity\User::class);
     }
 }

--- a/test/Fixture/Definition/PrivateConstructor/UserDefinition.php
+++ b/test/Fixture/Definition/PrivateConstructor/UserDefinition.php
@@ -9,15 +9,20 @@
  * @link https://github.com/localheinz/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Definition\DoesNotImplementInterface;
+namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\PrivateConstructor;
 
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
+use Localheinz\FactoryGirl\Definition\Definition;
 
 /**
- * Is not acceptable as it does not implement the DefinitionInterface.
+ * Is not acceptable as it has a private constructor.
  */
-final class UserDefinition
+final class UserDefinition implements Definition
 {
+    private function __construct()
+    {
+    }
+
     public function accept(FixtureFactory $factory)
     {
         $factory->defineEntity('Foo');

--- a/test/Fixture/Definition/ThrowsExceptionDuringConstruction/UserDefinition.php
+++ b/test/Fixture/Definition/ThrowsExceptionDuringConstruction/UserDefinition.php
@@ -9,22 +9,23 @@
  * @link https://github.com/localheinz/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Definition\PrivateConstructor;
+namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\ThrowsExceptionDuringConstruction;
 
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
 use Localheinz\FactoryGirl\Definition\Definition;
 
 /**
- * Is not acceptable as it has a private constructor.
+ * Is not acceptable as it throws an exception during construction.
  */
 final class UserDefinition implements Definition
 {
-    private function __construct()
+    public function __construct()
     {
+        throw new \RuntimeException();
     }
 
     public function accept(FixtureFactory $factory)
     {
-        $factory->defineEntity('Foo');
+        $factory->defineEntity(\Localheinz\FactoryGirl\Definition\Test\Fixture\Entity\User::class);
     }
 }

--- a/test/Fixture/Entity/User.php
+++ b/test/Fixture/Entity/User.php
@@ -9,7 +9,7 @@
  * @link https://github.com/localheinz/factory-girl-definition
  */
 
-namespace Localheinz\FactoryGirl\Definition\Test\Unit\Asset\Entity;
+namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
 
 final class User
 {

--- a/test/Unit/DefinitionsTest.php
+++ b/test/Unit/DefinitionsTest.php
@@ -25,7 +25,7 @@ final class DefinitionsTest extends Framework\TestCase
     {
         $this->expectException(Exception\InvalidDirectory::class);
 
-        Definitions::in(__DIR__ . '/Asset/Definition/NonExistentDirectory');
+        Definitions::in(__DIR__ . '/../Fixture/Definition/NonExistentDirectory');
     }
 
     public function testInIgnoresClassesWhichCanNotBeAutoloaded()
@@ -36,7 +36,7 @@ final class DefinitionsTest extends Framework\TestCase
             ->expects($this->never())
             ->method($this->anything());
 
-        Definitions::in(__DIR__ . '/Asset/Definition/CanNotBeAutoloaded')->registerWith($fixtureFactory);
+        Definitions::in(__DIR__ . '/../Fixture/Definition/CanNotBeAutoloaded')->registerWith($fixtureFactory);
     }
 
     public function testInIgnoresClassesWhichDoNotImplementProviderInterface()
@@ -47,7 +47,7 @@ final class DefinitionsTest extends Framework\TestCase
             ->expects($this->never())
             ->method($this->anything());
 
-        Definitions::in(__DIR__ . '/Asset/Definition/DoesNotImplementInterface')->registerWith($fixtureFactory);
+        Definitions::in(__DIR__ . '/../Fixture/Definition/DoesNotImplementInterface')->registerWith($fixtureFactory);
     }
 
     public function testInIgnoresClassesWhichAreAbstract()
@@ -58,7 +58,7 @@ final class DefinitionsTest extends Framework\TestCase
             ->expects($this->never())
             ->method($this->anything());
 
-        Definitions::in(__DIR__ . '/Asset/Definition/IsAbstract')->registerWith($fixtureFactory);
+        Definitions::in(__DIR__ . '/../Fixture/Definition/IsAbstract')->registerWith($fixtureFactory);
     }
 
     public function testInIgnoresClassesWhichHavePrivateConstructors()
@@ -69,7 +69,7 @@ final class DefinitionsTest extends Framework\TestCase
             ->expects($this->never())
             ->method($this->anything());
 
-        Definitions::in(__DIR__ . '/Asset/Definition/PrivateConstructor')->registerWith($fixtureFactory);
+        Definitions::in(__DIR__ . '/../Fixture/Definition/PrivateConstructor')->registerWith($fixtureFactory);
     }
 
     public function testInAcceptsClassesWhichAreAcceptable()
@@ -80,7 +80,7 @@ final class DefinitionsTest extends Framework\TestCase
             ->expects($this->once())
             ->method('defineEntity');
 
-        Definitions::in(__DIR__ . '/Asset/Definition/Acceptable')->registerWith($fixtureFactory);
+        Definitions::in(__DIR__ . '/../Fixture/Definition/Acceptable')->registerWith($fixtureFactory);
     }
 
     public function testThrowsInvalidDefinitionExceptionIfInstantiatingDefinitionsThrowsException()
@@ -93,7 +93,7 @@ final class DefinitionsTest extends Framework\TestCase
 
         $this->expectException(Exception\InvalidDefinition::class);
 
-        Definitions::in(__DIR__ . '/Asset/Definition/ThrowsExceptionDuringConstruction');
+        Definitions::in(__DIR__ . '/../Fixture/Definition/ThrowsExceptionDuringConstruction');
     }
 
     /**

--- a/test/Unit/ProjectCodeTest.php
+++ b/test/Unit/ProjectCodeTest.php
@@ -26,7 +26,7 @@ final class ProjectCodeTest extends Framework\TestCase
     public function testTestCodeIsAbstractOrFinal()
     {
         $this->assertClassesAreAbstractOrFinal(__DIR__ . '/..', [
-            'Unit/Asset/Definition/CanNotBeAutoloaded',
+            'Fixture/Definition/CanNotBeAutoloaded',
         ]);
     }
 }


### PR DESCRIPTION
This PR

* [x] moves fixtures into dedicated namespace