### PR TITLE
Fix: Suggest to install using --dev option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Provides an interface for, and an easy way to find and register entity definitio
 Run
 
 ```
-$ composer require localheinz/factory-girl-definition
+$ composer require --dev localheinz/factory-girl-definition
 ```
 
 ## Usage


### PR DESCRIPTION
This PR

* [x] suggests to install this package using `--dev` option

💁‍♂️ After all, it's a development dependency.