### PR TITLE
Fix: Use entity class name in fixtures

### DIFF
--- a/test/Fixture/Definition/Acceptable/UserDefinition.php
+++ b/test/Fixture/Definition/Acceptable/UserDefinition.php
@@ -15,6 +15,7 @@ namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\Acceptable;
 
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
 use Localheinz\FactoryGirl\Definition\Definition;
+use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
 
 /**
  * Is acceptable as it implements the interface.
@@ -23,6 +24,6 @@ final class UserDefinition implements Definition
 {
     public function accept(FixtureFactory $factory)
     {
-        $factory->defineEntity('Foo');
+        $factory->defineEntity(Entity\User::class);
     }
 }

--- a/test/Fixture/Definition/CanNotBeAutoloaded/UserDefinition.php
+++ b/test/Fixture/Definition/CanNotBeAutoloaded/UserDefinition.php
@@ -13,6 +13,7 @@ namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\CanNotBeAuto
 
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
 use Localheinz\FactoryGirl\Definition\Definition;
+use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
 
 /**
  * Is not acceptable as it can not be autoloaded (class name does not match file name).
@@ -21,6 +22,6 @@ final class MaybeUserDefinition implements Definition
 {
     public function accept(FixtureFactory $factory)
     {
-        $factory->defineEntity('Foo');
+        $factory->defineEntity(Entity\User::class);
     }
 }

--- a/test/Fixture/Definition/DoesNotImplementInterface/UserDefinition.php
+++ b/test/Fixture/Definition/DoesNotImplementInterface/UserDefinition.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\DoesNotImplementInterface;
 
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
+use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
 
 /**
  * Is not acceptable as it does not implement the DefinitionInterface.
@@ -22,6 +23,6 @@ final class UserDefinition
 {
     public function accept(FixtureFactory $factory)
     {
-        $factory->defineEntity('Foo');
+        $factory->defineEntity(Entity\User::class);
     }
 }

--- a/test/Fixture/Definition/IsAbstract/UserDefinition.php
+++ b/test/Fixture/Definition/IsAbstract/UserDefinition.php
@@ -15,6 +15,7 @@ namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\IsAbstract;
 
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
 use Localheinz\FactoryGirl\Definition\Definition;
+use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
 
 /**
  * Is not acceptable as it is abstract.
@@ -23,6 +24,6 @@ abstract class UserDefinition implements Definition
 {
     public function accept(FixtureFactory $factory)
     {
-        $factory->defineEntity(\Localheinz\FactoryGirl\Definition\Test\Fixture\Entity\User::class);
+        $factory->defineEntity(Entity\User::class);
     }
 }

--- a/test/Fixture/Definition/PrivateConstructor/UserDefinition.php
+++ b/test/Fixture/Definition/PrivateConstructor/UserDefinition.php
@@ -15,6 +15,7 @@ namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\PrivateConst
 
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
 use Localheinz\FactoryGirl\Definition\Definition;
+use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
 
 /**
  * Is not acceptable as it has a private constructor.
@@ -27,6 +28,6 @@ final class UserDefinition implements Definition
 
     public function accept(FixtureFactory $factory)
     {
-        $factory->defineEntity('Foo');
+        $factory->defineEntity(Entity\User::class);
     }
 }

--- a/test/Fixture/Definition/ThrowsExceptionDuringConstruction/UserDefinition.php
+++ b/test/Fixture/Definition/ThrowsExceptionDuringConstruction/UserDefinition.php
@@ -15,6 +15,7 @@ namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\ThrowsExcept
 
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
 use Localheinz\FactoryGirl\Definition\Definition;
+use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
 
 /**
  * Is not acceptable as it throws an exception during construction.
@@ -28,6 +29,6 @@ final class UserDefinition implements Definition
 
     public function accept(FixtureFactory $factory)
     {
-        $factory->defineEntity(\Localheinz\FactoryGirl\Definition\Test\Fixture\Entity\User::class);
+        $factory->defineEntity(Entity\User::class);
     }
 }


### PR DESCRIPTION
This PR

* [x] uses the actual entity class name in fixtures