### PR TITLE
Fix: Keep entries in .gitattributes sorted

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-/.travis/           export-ignore
 /.github/           export-ignore
+/.travis/           export-ignore
 /test/              export-ignore
 /.codeclimate.yml   export-ignore
 /.editorconfig      export-ignore


### PR DESCRIPTION
This PR

* [x] keeps entries in `.gitattributes` sorted