### PR TITLE
Fix: Prerequisite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ infection: vendor
 test: vendor
 	vendor/bin/phpunit --configuration=test/Unit/phpunit.xml
 
-vendor:
+vendor: composer.json composer.lock
 	composer self-update
 	composer validate
 	composer install


### PR DESCRIPTION
This PR

* [x] adds `composer.json` and `composer.lock` as prerequisites

Follows #36.

🤦‍♂️ 