### PR TITLE
Enhancement: Allow to provide definitions with an instance of Faker\Generator

### DIFF
--- a/src/Definitions.php
+++ b/src/Definitions.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Localheinz\FactoryGirl\Definition;
 
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
+use Faker\Generator;
 use Localheinz\Classy;
 
 final class Definitions
@@ -79,11 +80,33 @@ final class Definitions
      * Registers all found definitions with the specified fixture factory.
      *
      * @param FixtureFactory $fixtureFactory
+     *
+     * @return self
      */
-    public function registerWith(FixtureFactory $fixtureFactory)
+    public function registerWith(FixtureFactory $fixtureFactory): self
     {
         foreach ($this->definitions as $definition) {
             $definition->accept($fixtureFactory);
         }
+
+        return $this;
+    }
+
+    /**
+     * Provides all found definitions with the specified faker generator if they desire it.
+     *
+     * @param Generator $faker
+     *
+     * @return self
+     */
+    public function provideWith(Generator $faker): self
+    {
+        foreach ($this->definitions as $definition) {
+            if ($definition instanceof FakerAwareDefinition) {
+                $definition->provideWith($faker);
+            }
+        }
+
+        return $this;
     }
 }

--- a/src/FakerAwareDefinition.php
+++ b/src/FakerAwareDefinition.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition;
+
+use Faker\Generator;
+
+interface FakerAwareDefinition extends Definition
+{
+    public function provideWith(Generator $faker);
+}

--- a/test/Fixture/Definition/FakerAware/GroupDefinition.php
+++ b/test/Fixture/Definition/FakerAware/GroupDefinition.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\FakerAware;
+
+use FactoryGirl\Provider\Doctrine\FixtureFactory;
+use Faker\Generator;
+use Localheinz\FactoryGirl\Definition\FakerAwareDefinition;
+use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
+
+final class GroupDefinition implements FakerAwareDefinition
+{
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    public function accept(FixtureFactory $factory)
+    {
+        $factory->defineEntity(Entity\Group::class);
+    }
+
+    public function provideWith(Generator $faker)
+    {
+        $this->faker = $faker;
+    }
+
+    public function faker()
+    {
+        return $this->faker;
+    }
+}

--- a/test/Fixture/Definition/FakerAware/UserDefinition.php
+++ b/test/Fixture/Definition/FakerAware/UserDefinition.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\FakerAware;
+
+use FactoryGirl\Provider\Doctrine\FixtureFactory;
+use Localheinz\FactoryGirl\Definition\Definition;
+use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
+
+final class UserDefinition implements Definition
+{
+    public function accept(FixtureFactory $factory)
+    {
+        $factory->defineEntity(Entity\Group::class);
+    }
+}

--- a/test/Fixture/Entity/Group.php
+++ b/test/Fixture/Entity/Group.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
+
+final class Group
+{
+}

--- a/test/Unit/FakerAwareDefinitionTest.php
+++ b/test/Unit/FakerAwareDefinitionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Test\Unit;
+
+use Localheinz\FactoryGirl\Definition\Definition;
+use Localheinz\FactoryGirl\Definition\FakerAwareDefinition;
+use Localheinz\Test\Util\Helper;
+use PHPUnit\Framework;
+
+final class FakerAwareDefinitionTest extends Framework\TestCase
+{
+    use Helper;
+
+    public function testExtendsDefinitionInterface()
+    {
+        $this->assertInterfaceExtends(Definition::class, FakerAwareDefinition::class);
+    }
+}


### PR DESCRIPTION
This PR

* [x] adds a `FakerAwareDefinition` interface and allows to provide definitions with an instance of `Faker\Generator`