### PR TITLE
Enhancement: Provide AbstractDefinition which partially implements the FakerAwareDefinition

### DIFF
--- a/src/AbstractDefinition.php
+++ b/src/AbstractDefinition.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition;
+
+use Faker\Generator;
+
+abstract class AbstractDefinition implements FakerAwareDefinition
+{
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    final public function provideWith(Generator $faker)
+    {
+        $this->faker = $faker;
+    }
+
+    /**
+     * @throws \BadMethodCallException
+     *
+     * @return Generator
+     */
+    final public function faker(): Generator
+    {
+        if (null === $this->faker) {
+            throw new \BadMethodCallException(\sprintf(
+                'Before accessing, an instance of "%s" needs to be provided using provideWith()',
+                Generator::class
+            ));
+        }
+
+        return $this->faker;
+    }
+}

--- a/test/Fixture/Definition/ExtendsAbstractDefinition/UserDefinition.php
+++ b/test/Fixture/Definition/ExtendsAbstractDefinition/UserDefinition.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Test\Fixture\Definition\ExtendsAbstractDefinition;
+
+use FactoryGirl\Provider\Doctrine\FixtureFactory;
+use Localheinz\FactoryGirl\Definition\AbstractDefinition;
+use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
+
+final class UserDefinition extends AbstractDefinition
+{
+    public function accept(FixtureFactory $factory)
+    {
+        $factory->defineEntity(Entity\User::class);
+    }
+}

--- a/test/Unit/AbstractDefinitionTest.php
+++ b/test/Unit/AbstractDefinitionTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017 Andreas Möller.
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * @link https://github.com/localheinz/factory-girl-definition
+ */
+
+namespace Localheinz\FactoryGirl\Definition\Test\Unit;
+
+use Faker\Generator;
+use Localheinz\FactoryGirl\Definition\AbstractDefinition;
+use Localheinz\FactoryGirl\Definition\Definition;
+use Localheinz\FactoryGirl\Definition\FakerAwareDefinition;
+use Localheinz\FactoryGirl\Definition\Test\Fixture;
+use Localheinz\Test\Util\Helper;
+use PHPUnit\Framework;
+
+final class AbstractDefinitionTest extends Framework\TestCase
+{
+    use Helper;
+
+    public function testImplementsFakerAwareDefinitionInterface()
+    {
+        $this->assertClassImplementsInterface(FakerAwareDefinition::class, AbstractDefinition::class);
+    }
+
+    public function testFakerThrowsBadMethodCallExceptionIfDefinitionHasNotBeenProvidedWithFaker()
+    {
+        $definition = new Fixture\Definition\ExtendsAbstractDefinition\UserDefinition();
+
+        $this->expectException(\BadMethodCallException::class);
+        $this->expectExceptionMessage(\sprintf(
+            'Before accessing, an instance of "%s" needs to be provided using provideWith()',
+            Generator::class
+        ));
+
+        $definition->faker();
+    }
+
+    public function testFakerReturnsFakerWhenProvidedWithIt()
+    {
+        $faker = new Generator();
+
+        $definition = new Fixture\Definition\ExtendsAbstractDefinition\UserDefinition();
+
+        $definition->provideWith($faker);
+
+        $this->assertSame($faker, $definition->faker());
+    }
+}


### PR DESCRIPTION
This PR

* [x] adds an `AbstractDefinition` which partially implements the `FakerAwareInterface` 

Follows #41.