### PR TITLE
Enhancement: Update localheinz/php-cs-fixer-config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ jobs:
         - if [[ -n "$GITHUB_TOKEN" ]]; then composer config github-oauth.github.com $GITHUB_TOKEN; fi
 
       install:
-        - if [[ "$TRAVIS_PHP_VERSION" == "7.3" ]]; then composer remove --dev localheinz/php-cs-fixer-config; fi
         - if [[ "$WITH_LOWEST" == "true" ]]; then composer update --prefer-lowest; fi
         - if [[ "$WITH_LOCKED" == "true" ]]; then composer install; fi
         - if [[ "$WITH_HIGHEST" == "true" ]]; then composer update; fi

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "breerly/factory-girl-php": "^1.0.0",
     "infection/infection": "~0.7.0",
     "localheinz/composer-normalize": "^1.0.0",
-    "localheinz/php-cs-fixer-config": "~1.17.0",
+    "localheinz/php-cs-fixer-config": "~1.19.0",
     "localheinz/test-util": "0.5.0",
     "phpunit/phpunit": "^6.5.5"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "114989b404dcb0d26c8a5f2a094f1ad7",
+    "content-hash": "cf49102a6e3ca4d6ec6ddcdc991e56ae",
     "packages": [
         {
             "name": "localheinz/classy",
@@ -365,16 +365,16 @@
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "b8e9745fb9b06ea6664d8872c4505fb16df4611c"
+                "reference": "dc523135366eb68f22268d069ea7749486458562"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/b8e9745fb9b06ea6664d8872c4505fb16df4611c",
-                "reference": "b8e9745fb9b06ea6664d8872c4505fb16df4611c",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/dc523135366eb68f22268d069ea7749486458562",
+                "reference": "dc523135366eb68f22268d069ea7749486458562",
                 "shasum": ""
             },
             "require": {
@@ -405,7 +405,7 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2018-08-31T19:07:57+00:00"
+            "time": "2018-11-29T10:59:02+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -1009,16 +1009,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v2.13.1",
+            "version": "v2.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "54814c62d5beef3ba55297b9b3186ed8b8a1b161"
+                "reference": "b788ea0af899cedc8114dca7db119c93b6685da2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/54814c62d5beef3ba55297b9b3186ed8b8a1b161",
-                "reference": "54814c62d5beef3ba55297b9b3186ed8b8a1b161",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/b788ea0af899cedc8114dca7db119c93b6685da2",
+                "reference": "b788ea0af899cedc8114dca7db119c93b6685da2",
                 "shasum": ""
             },
             "require": {
@@ -1027,7 +1027,7 @@
                 "doctrine/annotations": "^1.2",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": "^5.6 || >=7.0 <7.3",
+                "php": "^5.6 || ^7.0",
                 "php-cs-fixer/diff": "^1.3",
                 "symfony/console": "^3.4.17 || ^4.1.6",
                 "symfony/event-dispatcher": "^3.0 || ^4.0",
@@ -1045,7 +1045,7 @@
             "require-dev": {
                 "johnkary/phpunit-speedtrap": "^1.1 || ^2.0 || ^3.0",
                 "justinrainbow/json-schema": "^5.0",
-                "keradus/cli-executor": "^1.1",
+                "keradus/cli-executor": "^1.2",
                 "mikey179/vfsstream": "^1.6",
                 "php-coveralls/php-coveralls": "^2.1",
                 "php-cs-fixer/accessible-object": "^1.0",
@@ -1065,6 +1065,11 @@
                 "php-cs-fixer"
             ],
             "type": "application",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.14-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "PhpCsFixer\\": "src/"
@@ -1096,7 +1101,7 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
-            "time": "2018-10-21T00:32:10+00:00"
+            "time": "2019-01-04T18:29:47+00:00"
         },
         {
             "name": "fzaninotto/faker",
@@ -1492,20 +1497,20 @@
         },
         {
             "name": "localheinz/php-cs-fixer-config",
-            "version": "1.17.0",
+            "version": "1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/localheinz/php-cs-fixer-config.git",
-                "reference": "d4835786b5e949ebaf76d29fc8b5b6237ee1e115"
+                "reference": "6237bcf8636243bc2d1a995f67c49ac58cb76188"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/php-cs-fixer-config/zipball/d4835786b5e949ebaf76d29fc8b5b6237ee1e115",
-                "reference": "d4835786b5e949ebaf76d29fc8b5b6237ee1e115",
+                "url": "https://api.github.com/repos/localheinz/php-cs-fixer-config/zipball/6237bcf8636243bc2d1a995f67c49ac58cb76188",
+                "reference": "6237bcf8636243bc2d1a995f67c49ac58cb76188",
                 "shasum": ""
             },
             "require": {
-                "friendsofphp/php-cs-fixer": "^2.13.1",
+                "friendsofphp/php-cs-fixer": "^2.14.0",
                 "php": "^5.6 || ^7.0"
             },
             "require-dev": {
@@ -1529,7 +1534,7 @@
             ],
             "description": "Provides a configuration factory and multiple rule sets for friendsofphp/php-cs-fixer.",
             "homepage": "https://github.com/localheinz/php-cs-fixer-config",
-            "time": "2018-11-27T07:03:30+00:00"
+            "time": "2019-01-04T23:09:58+00:00"
         },
         {
             "name": "localheinz/test-util",
@@ -3389,7 +3394,7 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.4.19",
+            "version": "v3.4.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
@@ -3457,17 +3462,85 @@
             "time": "2018-11-26T12:48:07+00:00"
         },
         {
-            "name": "symfony/debug",
-            "version": "v4.1.8",
+            "name": "symfony/contracts",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/debug.git",
-                "reference": "f9eea0cff99d14f97d69b24b17164098ece3fd32"
+                "url": "https://github.com/symfony/contracts.git",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/f9eea0cff99d14f97d69b24b17164098ece3fd32",
-                "reference": "f9eea0cff99d14f97d69b24b17164098ece3fd32",
+                "url": "https://api.github.com/repos/symfony/contracts/zipball/1aa7ab2429c3d594dd70689604b5cf7421254cdf",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "psr/cache": "When using the Cache contracts",
+                "psr/container": "When using the Service contracts",
+                "symfony/cache-contracts-implementation": "",
+                "symfony/service-contracts-implementation": "",
+                "symfony/translation-contracts-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\": ""
+                },
+                "exclude-from-classmap": [
+                    "**/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A set of abstractions extracted out of the Symfony components",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2018-12-05T08:06:11+00:00"
+        },
+        {
+            "name": "symfony/debug",
+            "version": "v4.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "e0a2b92ee0b5b934f973d90c2f58e18af109d276"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/e0a2b92ee0b5b934f973d90c2f58e18af109d276",
+                "reference": "e0a2b92ee0b5b934f973d90c2f58e18af109d276",
                 "shasum": ""
             },
             "require": {
@@ -3483,7 +3556,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -3510,24 +3583,25 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:51:29+00:00"
+            "time": "2018-11-28T18:24:18+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.1.8",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "8b93ce06506d58485893e2da366767dcc5390862"
+                "reference": "921f49c3158a276d27c0d770a5a347a3b718b328"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/8b93ce06506d58485893e2da366767dcc5390862",
-                "reference": "8b93ce06506d58485893e2da366767dcc5390862",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/921f49c3158a276d27c0d770a5a347a3b718b328",
+                "reference": "921f49c3158a276d27c0d770a5a347a3b718b328",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.1.3",
+                "symfony/contracts": "^1.0"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4"
@@ -3546,7 +3620,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -3573,20 +3647,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-26T10:26:29+00:00"
+            "time": "2018-12-01T08:52:38+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.1.8",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "71cc7693940bdad4dac4b038acd46b4f1ae7d2ca"
+                "reference": "2f4c8b999b3b7cadb2a69390b01af70886753710"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/71cc7693940bdad4dac4b038acd46b4f1ae7d2ca",
-                "reference": "71cc7693940bdad4dac4b038acd46b4f1ae7d2ca",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/2f4c8b999b3b7cadb2a69390b01af70886753710",
+                "reference": "2f4c8b999b3b7cadb2a69390b01af70886753710",
                 "shasum": ""
             },
             "require": {
@@ -3596,7 +3670,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -3623,20 +3697,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:51:29+00:00"
+            "time": "2018-11-11T19:52:12+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v4.1.8",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "68fbdcafe915db67adb13fddaec4532e684f6689"
+                "reference": "e53d477d7b5c4982d0e1bfd2298dbee63d01441d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/68fbdcafe915db67adb13fddaec4532e684f6689",
-                "reference": "68fbdcafe915db67adb13fddaec4532e684f6689",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e53d477d7b5c4982d0e1bfd2298dbee63d01441d",
+                "reference": "e53d477d7b5c4982d0e1bfd2298dbee63d01441d",
                 "shasum": ""
             },
             "require": {
@@ -3645,7 +3719,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -3672,20 +3746,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:51:29+00:00"
+            "time": "2018-11-11T19:52:12+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v4.1.8",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "31e5523373cb06163079ef46d0a2d507d70fe064"
+                "reference": "a9c38e8a3da2c03b3e71fdffa6efb0bda51390ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/31e5523373cb06163079ef46d0a2d507d70fe064",
-                "reference": "31e5523373cb06163079ef46d0a2d507d70fe064",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/a9c38e8a3da2c03b3e71fdffa6efb0bda51390ba",
+                "reference": "a9c38e8a3da2c03b3e71fdffa6efb0bda51390ba",
                 "shasum": ""
             },
             "require": {
@@ -3694,7 +3768,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -3726,7 +3800,7 @@
                 "configuration",
                 "options"
             ],
-            "time": "2018-11-11T19:51:29+00:00"
+            "time": "2018-11-11T19:52:12+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3961,16 +4035,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.1.8",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "471f6e24172366a97365baaae588ddaafbba9b20"
+                "reference": "2b341009ccec76837a7f46f59641b431e4d4c2b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/471f6e24172366a97365baaae588ddaafbba9b20",
-                "reference": "471f6e24172366a97365baaae588ddaafbba9b20",
+                "url": "https://api.github.com/repos/symfony/process/zipball/2b341009ccec76837a7f46f59641b431e4d4c2b0",
+                "reference": "2b341009ccec76837a7f46f59641b431e4d4c2b0",
                 "shasum": ""
             },
             "require": {
@@ -3979,7 +4053,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -4006,29 +4080,30 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-20T16:14:00+00:00"
+            "time": "2018-11-20T16:22:05+00:00"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v4.1.8",
+            "version": "v4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "87a801786adb053576dc025892e01fedde9b4fc7"
+                "reference": "ec076716412274e51f8a7ea675d9515e5c311123"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/87a801786adb053576dc025892e01fedde9b4fc7",
-                "reference": "87a801786adb053576dc025892e01fedde9b4fc7",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/ec076716412274e51f8a7ea675d9515e5c311123",
+                "reference": "ec076716412274e51f8a7ea675d9515e5c311123",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1.3"
+                "php": "^7.1.3",
+                "symfony/contracts": "^1.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -4055,7 +4130,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2018-11-11T19:51:29+00:00"
+            "time": "2018-11-11T19:52:12+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/src/AbstractDefinition.php
+++ b/src/AbstractDefinition.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -22,7 +22,7 @@ abstract class AbstractDefinition implements FakerAwareDefinition
      */
     private $faker;
 
-    final public function provideWith(Generator $faker)
+    final public function provideWith(Generator $faker): void
     {
         $this->faker = $faker;
     }

--- a/src/Definition.php
+++ b/src/Definition.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Definitions.php
+++ b/src/Definitions.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Exception/InvalidDefinition.php
+++ b/src/Exception/InvalidDefinition.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/Exception/InvalidDirectory.php
+++ b/src/Exception/InvalidDirectory.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/src/FakerAwareDefinition.php
+++ b/src/FakerAwareDefinition.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/Definition/Acceptable/UserDefinition.php
+++ b/test/Fixture/Definition/Acceptable/UserDefinition.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -22,7 +22,7 @@ use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
  */
 final class UserDefinition implements Definition
 {
-    public function accept(FixtureFactory $factory)
+    public function accept(FixtureFactory $factory): void
     {
         $factory->defineEntity(Entity\User::class);
     }

--- a/test/Fixture/Definition/DoesNotImplementInterface/UserDefinition.php
+++ b/test/Fixture/Definition/DoesNotImplementInterface/UserDefinition.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -21,7 +21,7 @@ use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
  */
 final class UserDefinition
 {
-    public function accept(FixtureFactory $factory)
+    public function accept(FixtureFactory $factory): void
     {
         $factory->defineEntity(Entity\User::class);
     }

--- a/test/Fixture/Definition/ExtendsAbstractDefinition/UserDefinition.php
+++ b/test/Fixture/Definition/ExtendsAbstractDefinition/UserDefinition.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -19,7 +19,7 @@ use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
 
 final class UserDefinition extends AbstractDefinition
 {
-    public function accept(FixtureFactory $factory)
+    public function accept(FixtureFactory $factory): void
     {
         $factory->defineEntity(Entity\User::class);
     }

--- a/test/Fixture/Definition/FakerAware/GroupDefinition.php
+++ b/test/Fixture/Definition/FakerAware/GroupDefinition.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -25,12 +25,12 @@ final class GroupDefinition implements FakerAwareDefinition
      */
     private $faker;
 
-    public function accept(FixtureFactory $factory)
+    public function accept(FixtureFactory $factory): void
     {
         $factory->defineEntity(Entity\Group::class);
     }
 
-    public function provideWith(Generator $faker)
+    public function provideWith(Generator $faker): void
     {
         $this->faker = $faker;
     }

--- a/test/Fixture/Definition/FakerAware/UserDefinition.php
+++ b/test/Fixture/Definition/FakerAware/UserDefinition.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -19,7 +19,7 @@ use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
 
 final class UserDefinition implements Definition
 {
-    public function accept(FixtureFactory $factory)
+    public function accept(FixtureFactory $factory): void
     {
         $factory->defineEntity(Entity\Group::class);
     }

--- a/test/Fixture/Definition/IsAbstract/UserDefinition.php
+++ b/test/Fixture/Definition/IsAbstract/UserDefinition.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -22,7 +22,7 @@ use Localheinz\FactoryGirl\Definition\Test\Fixture\Entity;
  */
 abstract class UserDefinition implements Definition
 {
-    public function accept(FixtureFactory $factory)
+    public function accept(FixtureFactory $factory): void
     {
         $factory->defineEntity(Entity\User::class);
     }

--- a/test/Fixture/Definition/PrivateConstructor/UserDefinition.php
+++ b/test/Fixture/Definition/PrivateConstructor/UserDefinition.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -26,7 +26,7 @@ final class UserDefinition implements Definition
     {
     }
 
-    public function accept(FixtureFactory $factory)
+    public function accept(FixtureFactory $factory): void
     {
         $factory->defineEntity(Entity\User::class);
     }

--- a/test/Fixture/Definition/ThrowsExceptionDuringConstruction/UserDefinition.php
+++ b/test/Fixture/Definition/ThrowsExceptionDuringConstruction/UserDefinition.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -27,7 +27,7 @@ final class UserDefinition implements Definition
         throw new \RuntimeException();
     }
 
-    public function accept(FixtureFactory $factory)
+    public function accept(FixtureFactory $factory): void
     {
         $factory->defineEntity(Entity\User::class);
     }

--- a/test/Fixture/Entity/Group.php
+++ b/test/Fixture/Entity/Group.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Fixture/Entity/User.php
+++ b/test/Fixture/Entity/User.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.

--- a/test/Unit/AbstractDefinitionTest.php
+++ b/test/Unit/AbstractDefinitionTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -27,12 +27,12 @@ final class AbstractDefinitionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testImplementsFakerAwareDefinitionInterface()
+    public function testImplementsFakerAwareDefinitionInterface(): void
     {
         $this->assertClassImplementsInterface(FakerAwareDefinition::class, AbstractDefinition::class);
     }
 
-    public function testFakerThrowsBadMethodCallExceptionIfDefinitionHasNotBeenProvidedWithFaker()
+    public function testFakerThrowsBadMethodCallExceptionIfDefinitionHasNotBeenProvidedWithFaker(): void
     {
         $definition = new Fixture\Definition\ExtendsAbstractDefinition\UserDefinition();
 
@@ -45,7 +45,7 @@ final class AbstractDefinitionTest extends Framework\TestCase
         $definition->faker();
     }
 
-    public function testFakerReturnsFakerWhenProvidedWithIt()
+    public function testFakerReturnsFakerWhenProvidedWithIt(): void
     {
         $faker = new Generator();
 

--- a/test/Unit/DefinitionsTest.php
+++ b/test/Unit/DefinitionsTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -30,14 +30,14 @@ final class DefinitionsTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testInRejectsNonExistentDirectory()
+    public function testInRejectsNonExistentDirectory(): void
     {
         $this->expectException(Exception\InvalidDirectory::class);
 
         Definitions::in(__DIR__ . '/../Fixture/Definition/NonExistentDirectory');
     }
 
-    public function testInIgnoresClassesWhichCanNotBeAutoloaded()
+    public function testInIgnoresClassesWhichCanNotBeAutoloaded(): void
     {
         $fixtureFactory = $this->prophesize(FixtureFactory::class);
 
@@ -48,7 +48,7 @@ final class DefinitionsTest extends Framework\TestCase
         Definitions::in(__DIR__ . '/../Fixture/Definition/CanNotBeAutoloaded')->registerWith($fixtureFactory->reveal());
     }
 
-    public function testInIgnoresClassesWhichDoNotImplementProviderInterface()
+    public function testInIgnoresClassesWhichDoNotImplementProviderInterface(): void
     {
         $fixtureFactory = $this->prophesize(FixtureFactory::class);
 
@@ -59,7 +59,7 @@ final class DefinitionsTest extends Framework\TestCase
         Definitions::in(__DIR__ . '/../Fixture/Definition/DoesNotImplementInterface')->registerWith($fixtureFactory->reveal());
     }
 
-    public function testInIgnoresClassesWhichAreAbstract()
+    public function testInIgnoresClassesWhichAreAbstract(): void
     {
         $fixtureFactory = $this->prophesize(FixtureFactory::class);
 
@@ -70,7 +70,7 @@ final class DefinitionsTest extends Framework\TestCase
         Definitions::in(__DIR__ . '/../Fixture/Definition/IsAbstract')->registerWith($fixtureFactory->reveal());
     }
 
-    public function testInIgnoresClassesWhichHavePrivateConstructors()
+    public function testInIgnoresClassesWhichHavePrivateConstructors(): void
     {
         $fixtureFactory = $this->prophesize(FixtureFactory::class);
 
@@ -81,7 +81,7 @@ final class DefinitionsTest extends Framework\TestCase
         Definitions::in(__DIR__ . '/../Fixture/Definition/PrivateConstructor')->registerWith($fixtureFactory->reveal());
     }
 
-    public function testInAcceptsClassesWhichAreAcceptable()
+    public function testInAcceptsClassesWhichAreAcceptable(): void
     {
         $fixtureFactory = $this->prophesize(FixtureFactory::class);
 
@@ -92,7 +92,7 @@ final class DefinitionsTest extends Framework\TestCase
         Definitions::in(__DIR__ . '/../Fixture/Definition/Acceptable')->registerWith($fixtureFactory->reveal());
     }
 
-    public function testFluentInterface()
+    public function testFluentInterface(): void
     {
         $definitions = Definitions::in(__DIR__ . '/../Fixture/Definition/Acceptable');
 
@@ -102,7 +102,7 @@ final class DefinitionsTest extends Framework\TestCase
         self::assertSame($definitions, $definitions->provideWith($this->prophesize(Generator::class)->reveal()));
     }
 
-    public function testInAcceptsClassesWhichAreAcceptableAndFakerAwareAndProvidesThemWithFaker()
+    public function testInAcceptsClassesWhichAreAcceptableAndFakerAwareAndProvidesThemWithFaker(): void
     {
         $faker = $this->prophesize(Generator::class);
 
@@ -132,7 +132,7 @@ final class DefinitionsTest extends Framework\TestCase
         self::assertSame($faker->reveal(), $fakerAwareDefinition->faker());
     }
 
-    public function testThrowsInvalidDefinitionExceptionIfInstantiatingDefinitionsThrowsException()
+    public function testThrowsInvalidDefinitionExceptionIfInstantiatingDefinitionsThrowsException(): void
     {
         $this->expectException(Exception\InvalidDefinition::class);
 

--- a/test/Unit/Exception/InvalidDefinitionTest.php
+++ b/test/Unit/Exception/InvalidDefinitionTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -24,12 +24,12 @@ final class InvalidDefinitionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testExtendsRuntimeException()
+    public function testExtendsRuntimeException(): void
     {
         $this->assertClassExtends(\RuntimeException::class, Exception\InvalidDefinition::class);
     }
 
-    public function testFromClassNameCreatesException()
+    public function testFromClassNameCreatesException(): void
     {
         $className = $this->faker()->word;
         $previousException = new \Exception();

--- a/test/Unit/Exception/InvalidDirectoryTest.php
+++ b/test/Unit/Exception/InvalidDirectoryTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -24,12 +24,12 @@ final class InvalidDirectoryTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testExtendsInvalidArgumentException()
+    public function testExtendsInvalidArgumentException(): void
     {
         $this->assertClassExtends(\InvalidArgumentException::class, Exception\InvalidDirectory::class);
     }
 
-    public function testNotDirectoryCreatesException()
+    public function testNotDirectoryCreatesException(): void
     {
         $directory = $this->faker()->word;
 

--- a/test/Unit/FakerAwareDefinitionTest.php
+++ b/test/Unit/FakerAwareDefinitionTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -25,7 +25,7 @@ final class FakerAwareDefinitionTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testExtendsDefinitionInterface()
+    public function testExtendsDefinitionInterface(): void
     {
         $this->assertInterfaceExtends(Definition::class, FakerAwareDefinition::class);
     }

--- a/test/Unit/ProjectCodeTest.php
+++ b/test/Unit/ProjectCodeTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /**
- * Copyright (c) 2017 Andreas Möller.
+ * Copyright (c) 2017 Andreas Möller
  *
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
@@ -24,12 +24,12 @@ final class ProjectCodeTest extends Framework\TestCase
 {
     use Helper;
 
-    public function testProductionClassesAreAbstractOrFinal()
+    public function testProductionClassesAreAbstractOrFinal(): void
     {
         $this->assertClassesAreAbstractOrFinal(__DIR__ . '/../../src');
     }
 
-    public function testProductionClassesHaveTests()
+    public function testProductionClassesHaveTests(): void
     {
         $this->assertClassesHaveTests(
             __DIR__ . '/../../src',
@@ -38,7 +38,7 @@ final class ProjectCodeTest extends Framework\TestCase
         );
     }
 
-    public function testTestClassesAreAbstractOrFinal()
+    public function testTestClassesAreAbstractOrFinal(): void
     {
         $this->assertClassesAreAbstractOrFinal(__DIR__ . '/..', [
             Fixture\Definition\CanNotBeAutoloaded\MaybeUserDefinition::class,


### PR DESCRIPTION
This PR

* [x] updates `localheinz/php-cs-fixer-config` 
* [x] runs `make cs`
* [x] does not remove `localheinz/php-cs-fixer-config` on PHP 7.3

💁‍♂️ For reference, see https://github.com/localheinz/php-cs-fixer-config/compare/1.17.0...1.19.0.