### PR TITLE
Fix: Do not self-update composer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ test: vendor
 	vendor/bin/phpunit --configuration=test/Unit/phpunit.xml
 
 vendor: composer.json composer.lock
-	composer self-update
 	composer validate
 	composer install
 	composer normalize


### PR DESCRIPTION
This PR

* [x] stops updating `composer` itself in `vendor` target of `Makefile`