### PR TITLE
Enhancement: Use ergebnis/phpstan-rules instead of localheinz/phpstan-rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
   "require-dev": {
     "breerly/factory-girl-php": "^1.0.3",
     "ergebnis/php-cs-fixer-config": "~1.0.0",
+    "ergebnis/phpstan-rules": "~0.14.0",
     "ergebnis/test-util": "~0.9.0",
     "infection/infection": "~0.14.2",
     "jangregor/phpstan-prophecy": "~0.4.2",
     "localheinz/composer-normalize": "^1.3.1",
-    "localheinz/phpstan-rules": "~0.13.0",
     "phpstan/phpstan": "~0.11.19",
     "phpstan/phpstan-deprecation-rules": "~0.11.2",
     "phpstan/phpstan-strict-rules": "~0.11.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a1f3da605b5742ecc73fac182c597690",
+    "content-hash": "a30d0f27b127e319f5c3a70fd61e0df5",
     "packages": [
         {
             "name": "localheinz/classy",
@@ -940,6 +940,73 @@
             "time": "2019-11-25T19:01:52+00:00"
         },
         {
+            "name": "ergebnis/phpstan-rules",
+            "version": "0.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ergebnis/phpstan-rules.git",
+                "reference": "217772cd009ec8a10f44c827137c4c4c85126258"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ergebnis/phpstan-rules/zipball/217772cd009ec8a10f44c827137c4c4c85126258",
+                "reference": "217772cd009ec8a10f44c827137c4c4c85126258",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "nikic/php-parser": "^4.2.3",
+                "php": "^7.2",
+                "phpstan/phpstan": "~0.11.15 || ~0.12.0"
+            },
+            "replace": {
+                "localheinz/phpstan-rules": "*"
+            },
+            "require-dev": {
+                "ergebnis/php-cs-fixer-config": "~1.1.0",
+                "ergebnis/test-util": "~0.9.0",
+                "infection/infection": "~0.13.6",
+                "localheinz/composer-normalize": "^1.3.1",
+                "nette/di": "^3.0.1",
+                "phpstan/phpstan-deprecation-rules": "~0.11.2",
+                "phpstan/phpstan-strict-rules": "~0.11.1",
+                "phpunit/phpunit": "^8.5.0",
+                "psr/container": "^1.0.0",
+                "zendframework/zend-servicemanager": "^2.0.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Ergebnis\\PHPStan\\Rules\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Möller",
+                    "email": "am@localheinz.com"
+                }
+            ],
+            "description": "Provides additional rules for phpstan/phpstan.",
+            "homepage": "https://github.com/ergebnis/phpstan-rules",
+            "keywords": [
+                "PHPStan",
+                "phpstan-extreme-rules",
+                "phpstan-rules"
+            ],
+            "time": "2019-12-09T22:36:56+00:00"
+        },
+        {
             "name": "ergebnis/test-util",
             "version": "0.9.0",
             "source": {
@@ -1666,69 +1733,8 @@
                 "json",
                 "printer"
             ],
+            "abandoned": "ergebnis/json-printer",
             "time": "2018-08-11T23:54:50+00:00"
-        },
-        {
-            "name": "localheinz/phpstan-rules",
-            "version": "0.13.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/localheinz/phpstan-rules.git",
-                "reference": "e05ea16b61e48436a9ebb98e432de56b2dcf2034"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/localheinz/phpstan-rules/zipball/e05ea16b61e48436a9ebb98e432de56b2dcf2034",
-                "reference": "e05ea16b61e48436a9ebb98e432de56b2dcf2034",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^4.2.3",
-                "php": "^7.1",
-                "phpstan/phpstan": "~0.11.15"
-            },
-            "require-dev": {
-                "infection/infection": "~0.13.6",
-                "localheinz/composer-normalize": "^1.3.1",
-                "localheinz/php-cs-fixer-config": "~1.23.0",
-                "localheinz/test-util": "~0.7.0",
-                "phpstan/phpstan-deprecation-rules": "~0.11.2",
-                "phpstan/phpstan-strict-rules": "~0.11.1",
-                "phpunit/phpunit": "^7.5.16",
-                "psr/container": "^1.0.0",
-                "zendframework/zend-servicemanager": "^2.0.0"
-            },
-            "type": "phpstan-extension",
-            "extra": {
-                "phpstan": {
-                    "includes": [
-                        "rules.neon"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Localheinz\\PHPStan\\Rules\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Möller",
-                    "email": "am@localheinz.com"
-                }
-            ],
-            "description": "Provides additional rules for phpstan/phpstan.",
-            "homepage": "https://github.com/localheinz/phpstan-rules",
-            "keywords": [
-                "PHPStan",
-                "phpstan-extreme-rules",
-                "phpstan-rules"
-            ],
-            "time": "2019-10-15T09:23:25+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,16 +1,17 @@
 includes:
+	- vendor/ergebnis/phpstan-rules/rules.neon
 	- vendor/jangregor/phpstan-prophecy/src/extension.neon
-	- vendor/localheinz/phpstan-rules/rules.neon
 	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
 	- vendor/phpstan/phpstan-strict-rules/rules.neon
 	- vendor/phpstan/phpstan/conf/bleedingEdge.neon
 	- vendor/phpstan/phpstan/conf/config.levelmax.neon
 
 parameters:
-	classesAllowedToBeExtended:
-		- InvalidArgumentException
-		- Localheinz\FactoryGirl\Definition\AbstractDefinition
-		- RuntimeException
+	ergebnis:
+		classesAllowedToBeExtended:
+			- InvalidArgumentException
+			- Localheinz\FactoryGirl\Definition\AbstractDefinition
+			- RuntimeException
 	ignoreErrors:
 		- '#Method Localheinz\\FactoryGirl\\Definition\\Definition::accept\(\) has no return typehint specified\.#'
 		- '#Method Localheinz\\FactoryGirl\\Definition\\FakerAwareDefinition::provideWith\(\) has no return typehint specified\.#'


### PR DESCRIPTION
This PR

* [x] uses `ergebnis/phpstan-rules` instead of `localheinz/phpstan-rules`