### PR TITLE
Fix: Use main as default branch name

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,7 +1,7 @@
 # https://github.com/probot/settings
 
 branches:
-  - name: "master"
+  - name: "main"
 
     # https://developer.github.com/v3/repos/branches/#remove-branch-protection
     # https://developer.github.com/v3/repos/branches/#update-branch-protection
@@ -80,7 +80,7 @@ repository:
   allow_rebase_merge: false
   allow_squash_merge: false
   archived: false
-  default_branch: "master"
+  default_branch: "main"
   delete_branch_on_merge: true
   description: ":girl: Provides an interface for, and an easy way to find and register entity definitions for breerly/factory-girl-php."
   has_downloads: true

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -6,7 +6,7 @@ on: # yamllint disable-line rule:truthy
   pull_request: null
   push:
     branches:
-      - "master"
+      - "main"
 
 env:
   MIN_COVERED_MSI: 95

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`2.0.1...master`][2.0.1...master]
+For a full diff see [`2.0.1...main`][2.0.1...main]
 
 ## [`2.0.1`][2.0.1]
 
@@ -118,7 +118,7 @@ For a full diff see [`740095e...0.1.0`][740095e...0.1.0].
 [1.2.0...1.3.0]: https://github.com/ergebnis/factory-girl-definition/compare/1.1.0...1.3.0
 [1.3.0...2.0.0]: https://github.com/ergebnis/factory-girl-definition/compare/1.3.0...2.0.0
 [2.0.0...2.0.1]: https://github.com/ergebnis/factory-girl-definition/compare/2.0.0...2.0.1
-[2.0.1...master]: https://github.com/ergebnis/factory-girl-definition/compare/2.0.1...master
+[2.0.1...main]: https://github.com/ergebnis/factory-girl-definition/compare/2.0.1...main
 
 [#1]: https://github.com/ergebnis/factory-girl-definition/pull/1
 [#3]: https://github.com/ergebnis/factory-girl-definition/pull/3

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # factory-girl-definition
 
-[![Integrate](https://github.com/ergebnis/factory-girl-definition/workflows/Integrate/badge.svg?branch=master)](https://github.com/ergebnis/factory-girl-definition/actions)
-[![Prune](https://github.com/ergebnis/factory-girl-definition/workflows/Prune/badge.svg?branch=master)](https://github.com/ergebnis/factory-girl-definition/actions)
-[![Release](https://github.com/ergebnis/factory-girl-definition/workflows/Release/badge.svg?branch=master)](https://github.com/ergebnis/factory-girl-definition/actions)
-[![Renew](https://github.com/ergebnis/factory-girl-definition/workflows/Renew/badge.svg?branch=master)](https://github.com/ergebnis/factory-girl-definition/actions)
+[![Integrate](https://github.com/ergebnis/factory-girl-definition/workflows/Integrate/badge.svg?branch=main)](https://github.com/ergebnis/factory-girl-definition/actions)
+[![Prune](https://github.com/ergebnis/factory-girl-definition/workflows/Prune/badge.svg?branch=main)](https://github.com/ergebnis/factory-girl-definition/actions)
+[![Release](https://github.com/ergebnis/factory-girl-definition/workflows/Release/badge.svg?branch=main)](https://github.com/ergebnis/factory-girl-definition/actions)
+[![Renew](https://github.com/ergebnis/factory-girl-definition/workflows/Renew/badge.svg?branch=main)](https://github.com/ergebnis/factory-girl-definition/actions)
 
-[![Code Coverage](https://codecov.io/gh/ergebnis/factory-girl-definition/branch/master/graph/badge.svg)](https://codecov.io/gh/ergebnis/factory-girl-definition)
+[![Code Coverage](https://codecov.io/gh/ergebnis/factory-girl-definition/branch/main/graph/badge.svg)](https://codecov.io/gh/ergebnis/factory-girl-definition)
 [![Type Coverage](https://shepherd.dev/github/ergebnis/factory-girl-definition/coverage.svg)](https://shepherd.dev/github/ergebnis/factory-girl-definition)
 
 [![Latest Stable Version](https://poser.pugx.org/ergebnis/factory-girl-definition/v/stable)](https://packagist.org/packages/ergebnis/factory-girl-definition)
@@ -115,7 +115,7 @@ Please have a look at [`CONTRIBUTING.md`](.github/CONTRIBUTING.md).
 
 ## Code of Conduct
 
-Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/master/CODE_OF_CONDUCT.md).
+Please have a look at [`CODE_OF_CONDUCT.md`](https://github.com/ergebnis/.github/blob/main/CODE_OF_CONDUCT.md).
 
 This package is licensed using the MIT License.
 


### PR DESCRIPTION
This PR

* [x] uses `main` as default branch name

✊🏿 Black lives matter.